### PR TITLE
Update orimorph.lexc

### DIFF
--- a/analyzer/orimorph.lexc
+++ b/analyzer/orimorph.lexc
@@ -28,43 +28,43 @@ LEXICON InanimNumber
 +Pl+Acc:ଗୁଡ଼ିକୁ Definiteness;
 
 LEXICON Honorific
-+Hon:ଙ୍କ୍ Case;
-+Hon:ଙ୍କ Case;
-Case;
++Hon:ଙ୍କ୍ Definiteness;
++Hon:ଙ୍କ Definiteness;
+Definiteness;
 
 LEXICON Case
 @U.ANIM.HUMAN@ AnimCase;
 @U.ANIM.NONHUMAN@ InanimCase;
 
 LEXICON AnimCase
-+Nom:0 Definiteness;
-+Acc:କୁ Definiteness;
-+Acc:ଙ୍କୁ Definiteness;
-+Gen:ର Definiteness;
-+Instr:ରେ Definiteness;
-+Loc:ରେ Definiteness;
-+Abl:ରୁ Definiteness;
++Nom:0 #;
++Acc:କୁ #;
++Acc:ଙ୍କୁ #;
++Gen:ର #;
++Instr:ରେ #;
++Loc:ରେ #;
++Abl:ରୁ #;
 
 LEXICON InanimCase
-+Nom:0 Definiteness;
-+Instr:ଦ୍ୱର Definiteness;
-+Loc:ଠାରେ Definiteness;
-+Abl:ଠାରୁ Definiteness;
++Nom:0 #;
++Instr:ଦ୍ୱାରା #;
++Loc:ଠାରେ #;
++Abl:ଠାରୁ #;
 
 LEXICON Definiteness
 @U.ANIM.HUMAN@ AnimDefiniteness;
 @U.ANIM.NONHUMAN@ InanimDefiniteness;
-#;
+Case;
 
-LEXICON AnimDefiniteness
-+Def:କ #;
+LEXICON AnimDefiniteness ! Article comes before case suffix, and only occurs with singular.
++Def:କ Case;
 
 LEXICON InanimDefiniteness
-+Def:ଟି #;
-+Def:ଟା #;
-+Indef:ଟେ #;
-+Indef:ଟିଏ #;
-+Indef:ଟାଏ #;
++Def:ଟି Case;
++Def:ଟା Case;
++Indef:ଟେ Case;
++Indef:ଟିଏ Case;
++Indef:ଟାଏ Case;
 
 LEXICON Stem
 ^GUESSNOUNSTEM Animacy;
@@ -7371,7 +7371,7 @@ Nଉପଦୁର୍ଗ Animacy;
 ବାଧା #;
 ଆବଶ୍ୟକ #;
 ଦ୍ୱିପଦପ୍ରାଣୀ #;
-ଚଢ଼େଇ #;
+ଚଢ଼େଇ #;
 ଚଢ଼େଇ #;
 ଜନ୍ମ #;
 ଟୁକୁରା #;
@@ -7455,7 +7455,7 @@ Nଉପଦୁର୍ଗ Animacy;
 ବହି #;
 ପୁସ୍ତକ #;
 ବହି #;
-ବହିଗୁଡ଼ିକ #;
+ବହିଗୁଡ଼ିକ #;
 ସାହସବୃଦ୍ଧି #;
 ବରଦାନ #;
 ବର୍ବରତା #;
@@ -9070,7 +9070,7 @@ Nଉପଦୁର୍ଗ Animacy;
 ଫୁଲ #;
 ପୁଷ୍ପିତ #;
 ବଢ଼ନା #;
-ଫୁଲଗୁଡ଼ିକ #;
+ଫୁଲଗୁଡ଼ିକ #;
 ଫୁଲବାଲୀ #;
 ଅନର୍ଗଳ #;
 ଲୋମଯୁକ୍ତ #;
@@ -9642,9 +9642,9 @@ Nଉପଦୁର୍ଗ Animacy;
 ଭୟାନକ #;
 ଭୟବିହ୍ୱଳତାରୁ #;
 ଭୟଭୀତ #;
-ଘୋଡ଼ା #;
 ଘୋଡ଼ା #;
-ଘୋଡ଼ାମାନେ #;
+ଘୋଡ଼ା #;
+ଘୋଡ଼ାମାନେ #;
 ଚାବୁକ #;
 ଅତିଥିସେବକ #;
 ପରିଚାରିକା #;
@@ -9655,7 +9655,7 @@ Nଉପଦୁର୍ଗ Animacy;
 ଜଲ୍‌ଦି-ଜଲ୍‌ଦି #;
 ରାଗରୁ #;
 ଘର #;
-ଘରଗୁଡ଼ିକ #;
+ଘରଗୁଡ଼ିକ #;
 ଘର #;
 ତଥାପି #;
 ଫେରିବାଲା #;
@@ -13209,7 +13209,7 @@ leakବହିବା #;
 ତିନିଗୁଣା #;
 ଗଛ #;
 ବୃକ୍ଷବିହୀନ #;
-ଗଛଗୁଡ଼ିକ #;
+ଗଛଗୁଡ଼ିକ #;
 କମ୍ପିବା #;
 କମ୍ପନ #;
 କମ୍ପୁଥିବା #;
@@ -13272,7 +13272,7 @@ leakବହିବା #;
 ବାର #;
 ବାର #;
 ବିଂଶତମ #;
-କୋଡ଼ିଏ #;
+କୋଡ଼ିଏ #;
 କୋଡ଼ିଏ #;
 କୋଡିଏ #;
 ଦୁଇଥର #;


### PR DESCRIPTION
Fixed typo for dwara, and put definiteness before case. Untested, but I don't think I broke anything.